### PR TITLE
Use token for uploading CodeCov report

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,8 @@ jobs:
           script-path: recipe.cake
           target: CI
           cake-version: 1.3.0
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload Issues
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:


### PR DESCRIPTION
Use token for uploading to CodeCov to avoid rate limiting